### PR TITLE
Add support for npm start usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node discord_bot.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Nabrok.9023",


### PR DESCRIPTION
By default, `npm start` executes `node server.js`. But since that it should be `node discord_bot.js`, I've added it.