### PR TITLE
Message of the day improvements

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -17,9 +17,8 @@ member_role = "" # Name of the role guild members go in
 motd_channel = "" # Will set the channel description to the guild motd
 motd_convert_urls = true # Convert urls from the motd that don't start with http:// to actual urls that discord parses to a link
 motd_excluded_subdomains = [ # An array of url subdomains in regular expressions of which the url should not be converted
-  "[^\\.]*ts[^\\.]*", # ts.example.com
-  "[^\\.]*ts3[^\\.]*", # ts3.example.com
-  "[^\\.]*teamspeak[^\\.]*" # teamspeak.example.com
+  "[^\\.]*ts[^\\.]*", # *ts*.example.com
+  "[^\\.]*teamspeak[^\\.]*" # *teamspeak*.example.com
 ]
 
 [discord]

--- a/config/default.toml
+++ b/config/default.toml
@@ -15,6 +15,12 @@ id  = "" # Guild unique ID in format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX, this can 
 key = "" # API Key from top guild rank with the "guilds" permission
 member_role = "" # Name of the role guild members go in
 motd_channel = "" # Will set the channel description to the guild motd
+motd_convert_urls = true # Convert urls from the motd that don't start with http:// to actual urls that discord parses to a link
+motd_excluded_subdomains = [ # An array of url subdomains in regular expressions of which the url should not be converted
+  "[^\\.]*ts[^\\.]*", # ts.example.com
+  "[^\\.]*ts3[^\\.]*", # ts3.example.com
+  "[^\\.]*teamspeak[^\\.]*" # teamspeak.example.com
+]
 
 [discord]
 clientid = "" # Used to generate a link to add the bot to a server

--- a/config/default.toml
+++ b/config/default.toml
@@ -15,8 +15,8 @@ id  = "" # Guild unique ID in format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX, this can 
 key = "" # API Key from top guild rank with the "guilds" permission
 member_role = "" # Name of the role guild members go in
 motd_channel = "" # Will set the channel description to the guild motd
-motd_convert_urls = true # Convert urls from the motd that don't start with http:// to actual urls that discord parses to a link
-motd_excluded_subdomains = [ # An array of url subdomains in regular expressions of which the url should not be converted
+motd_convert_urls = true # Convert urls in the guild motd to actual urls that discord parses to a link, if they don't start with e.g. "http://"
+motd_excluded_subdomains = [ # An array of url subdomains of which the url should not be converted (these are regular expressions)
   "[^\\.]*ts[^\\.]*", # *ts*.example.com
   "[^\\.]*teamspeak[^\\.]*" # *teamspeak*.example.com
 ]

--- a/features/motd.js
+++ b/features/motd.js
@@ -1,8 +1,9 @@
 var
-	Autolinker = require('autolinker'),
 	async = require('async'),
+	Autolinker = require('autolinker'),
 	config = require('config'),
 	gw2 = require('../lib/gw2_api')
+	parseDomain = require('parse-domain'),
 ;
 
 var guild_id = config.has('guild.id') ? config.get('guild.id') : null;
@@ -41,11 +42,12 @@ module.exports = function(bot) {
 
 		// Convert all urls to a proper url if enabled
 		if (convert_urls) {
-			var regex = new RegExp('('+excluded_subdomains.join('|')+')\.[^\.]*\.');
+			var regex = new RegExp('('+excluded_subdomains.join('|')+')');
 			text = Autolinker.link(text, {
 				replaceFn: function(match) {
 					if (match.getType() === 'url') {
-						if (excluded_subdomains.length === 0 || ! match.url.match(regex)) {
+						var sub = parseDomain(match.url).subdomain;
+						if (excluded_subdomains.length === 0 || ! sub.match(regex)) {
 							return match.getUrl();
 						}
 					}

--- a/features/motd.js
+++ b/features/motd.js
@@ -44,8 +44,10 @@ module.exports = function(bot) {
 			var regex = new RegExp('('+excluded_subdomains.join('|')+')\.[^\.]*\.');
 			text = Autolinker.link(text, {
 				replaceFn: function(match) {
-					if (match.getType() === 'url' && ! match.url.match(regex)) {
-						return match.getUrl();
+					if (match.getType() === 'url') {
+						if (excluded_subdomains.length === 0 || ! match.url.match(regex)) {
+							return match.getUrl();
+						}
 					}
 					return false;
 				}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "autolinker": "^1.1.0",
     "config": "^1.21.0",
     "discord.js": "^8.0.0",
+    "parse-domain": "^0.2.1",
     "redis": "^2.6.2",
     "request": "^2.74.0",
     "toml": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "async": "^2.0.1",
+    "autolinker": "^1.1.0",
     "config": "^1.21.0",
     "discord.js": "^8.0.0",
     "redis": "^2.6.2",


### PR DESCRIPTION
This includes two QoL improvements for the message of the day:
- URL's that are not prefixed with `http://` will be automatically prefixed so that Discord makes them clickable. This also includes a configurable list of excluded subdomains. By default it will exclude any URL that has *ts* or *teamspeak* somewhere in the subdomain.
- Sometimes the ingame message can have extra spaces and newlines for whatever reason. These are now trimmed away.