### PR TITLE
Update phrases and include guest WvW worlds

### DIFF
--- a/features/wvw_score.js
+++ b/features/wvw_score.js
@@ -20,6 +20,28 @@ function countPPT(match, color) {
 	}, 0);
 }
 
+function formatWorldNames(worlds, color) {
+	switch (color) {
+		case "green":
+			color = phrases.get("WVWSCORE_GREEN_COLOR");
+			break;
+		case "red":
+			color = phrases.get("WVWSCORE_RED_COLOR");
+			break;
+		case "blue":
+			color = phrases.get("WVWSCORE_BLUE_COLOR");
+			break;
+		default:
+			color = '';
+			break;
+	}
+	if (color) {
+		return Object.keys(worlds).map(c => worlds[c]).join(' + ')+' ('+color+')';
+	} else {
+		return Object.keys(worlds).map(c => worlds[c]).join(' + ');
+	}
+}
+
 function messageReceived(message) {
 	if (message.content.match(new RegExp('^!'+phrases.get("CORE_HELP")+'$', 'i'))) {
 		message.author.sendMessage(phrases.get("WVWSCORE_HELP"));
@@ -40,12 +62,22 @@ function messageReceived(message) {
 			gw2.request('/v2/wvw/matches?world='+world, null, next, { ttl: 5000 });
 		},
 		function(match, next) {
-			var world_ids = Object.keys(match.worlds).map(c => match.worlds[c]);
+			var world_ids = Object.keys(match.all_worlds).map(c => match.all_worlds[c]);
 			gw2.getWorlds(world_ids, function(err, worlds) {
 				if (err) return next(err);
+				var names = [];
+				var colors = Object.keys(match.all_worlds);
+				for (var c in colors) {
+					var color = colors[c];
+					names[color] = {};
+					for (var w in match.all_worlds[color]) {
+						var world = match.all_worlds[color][w];
+						names[color][world] = worlds[world].name;
+					}
+				}
 				var scores = Object.keys(match.worlds).map(color => ({
 					color: color,
-					name: worlds[match.worlds[color]].name,
+					names: names[color],
 					score: match.scores[color],
 					ppt: countPPT(match, color),
 					kills: match.kills[color],
@@ -57,12 +89,12 @@ function messageReceived(message) {
 	], function(err, scores) {
 		var result;
 		if (message.content.match(new RegExp('^!'+score_cmd+'$', 'i')))
-			result = scores.sort((a, b) => (b.score - a.score)).map(world => (world.name+': '+world.score.toLocaleString()+' (+'+world.ppt+')')).join("\n");
+			result = scores.sort((a, b) => (b.score - a.score)).map(world => (formatWorldNames(world.names, world.color)+': '+world.score.toLocaleString()+' (+'+world.ppt+')')).join("\n");
 		else if (message.content.match(new RegExp('^!'+kd_cmd+'$', 'i')))
-			result = scores.sort((a, b) => ((b.kills / b.deaths) - (a.kills / a.deaths))).map(world => (world.name+': '+world.kills.toLocaleString()+'/'+world.deaths.toLocaleString()+' = '+(world.kills / world.deaths).toLocaleString())).join("\n");
+			result = scores.sort((a, b) => ((b.kills / b.deaths) - (a.kills / a.deaths))).map(world => (formatWorldNames(world.names, world.color)+': '+world.kills.toLocaleString()+'/'+world.deaths.toLocaleString()+' = '+(world.kills / world.deaths).toLocaleString())).join("\n");
 		else if (message.content.match(new RegExp('^!'+relscore_cmd+'$', 'i'))) {
 			var sorted = scores.sort((a, b) => (b.score - a.score));
-			result = sorted.map((world, index) => (world.name+': '+((index === 0) ? world.score : world.score - sorted[index - 1].score).toLocaleString() +' (+'+world.ppt+')')).join("\n");
+			result = sorted.map((world, index) => (formatWorldNames(world.names, world.color)+': '+((index === 0) ? world.score : world.score - sorted[index - 1].score).toLocaleString() +' (+'+world.ppt+')')).join("\n");
 		}
 		message.channel.stopTyping(function() {
 			message.reply("```"+result+"```");

--- a/features/wvw_score.js
+++ b/features/wvw_score.js
@@ -62,7 +62,7 @@ function messageReceived(message) {
 			gw2.request('/v2/wvw/matches?world='+world, null, next, { ttl: 5000 });
 		},
 		function(match, next) {
-			var world_ids = Object.keys(match.all_worlds).map(c => match.all_worlds[c]);
+			var world_ids = [].concat.apply([], Object.keys(match.all_worlds).map(c => match.all_worlds[c]));
 			gw2.getWorlds(world_ids, function(err, worlds) {
 				if (err) return next(err);
 				var names = [];

--- a/phrases/builds.en.json
+++ b/phrases/builds.en.json
@@ -1,5 +1,5 @@
 {
 	"BUILDS_BUILD": "build",
-	"BUILDS_HELP": "`!build [character_name] (pve|wvw|pvp)` - Show the characters specializations and traits for the game mode.",
+	"BUILDS_HELP": "`!build [character_name] (pve|wvw|pvp)` - Show the character's specializations and traits for the given game mode.",
 	"BUILDS_NO_CHARACTER": "You do not have a character named \"%{name}\"."
 }

--- a/phrases/core.en.json
+++ b/phrases/core.en.json
@@ -1,5 +1,5 @@
 {
 	"CORE_HELP": "help",
-	"CORE_NO_KEY": "Sorry, I don't know who you are.  Please direct message me \"link\" to add a Guild Wars 2 API key.",
-	"CORE_MISSING_SCOPE": "You do not have the **%{scope}** permission on your API key.  Message me \"link\" to add a new key with this permission."
+	"CORE_NO_KEY": "Sorry, I don't know who you are. Please direct message me \"link\" to add a Guild Wars 2 API key.",
+	"CORE_MISSING_SCOPE": "You do not have the **%{scope}** permission on your API key. Message me \"link\" to add a new key with this permission."
 }

--- a/phrases/link.en.json
+++ b/phrases/link.en.json
@@ -2,8 +2,8 @@
 	"LINK_LINK": "link",
 	"LINK_HELP": "`link` - Initiate the process of adding an API key (only in direct message)",
 	"LINK_REPLY_WITH_KEY": "Please reply with a key from https://account.arena.net/applications - include the code **%{code}** in the key name field.",
-	"LINK_ERROR": "Sorry, an error occurred.  Please try again later.",
-	"LINK_KEY_DOESNT_MATCH": "The key your provided does not have the code **%{code}** in the name.",
-	"LINK_KEY_DETAILS": "The key **%{name}** has been associated with you.  This key grants the following permissions: %{permissions}",
-	"LINK_WELCOME": "Welcome!  Send me the message \"link\" when you are ready to apply a Guild Wars 2 API key."
+	"LINK_ERROR": "Sorry, an error occurred. Please try again later.",
+	"LINK_KEY_DOESNT_MATCH": "The key you provided does not have the code **%{code}** in the name. Please create a new key and include the code in the key name field.",
+	"LINK_KEY_DETAILS": "The key **%{name}** has been associated with you. This key grants the following permissions: %{permissions}",
+	"LINK_WELCOME": "Welcome! Send me the message \"link\" when you are ready to apply a Guild Wars 2 API key."
 }

--- a/phrases/wvw_score.en.json
+++ b/phrases/wvw_score.en.json
@@ -2,5 +2,5 @@
 	"WVWSCORE_SCORE": "score",
 	"WVWSCORE_RELSCORE": "relscore",
 	"WVWSCORE_KD": "kd",
-	"WVWSCORE_HELP": "`!score` - Show the scores for your current match-up.\n`!relscore` - Show the overall score for the top server and the difference to the server above for second and third place.\n`!kd` - Show the kill/death ratio"
+	"WVWSCORE_HELP": "`!score` - Show the scores of your current WvW match-up.\n`!relscore` - Show the overall WvW score of the top world, along with the differences with the worlds on the second and the third place.\n`!kd` - Show the kill/death ratio of your current WvW match-up."
 }

--- a/phrases/wvw_score.en.json
+++ b/phrases/wvw_score.en.json
@@ -2,5 +2,8 @@
 	"WVWSCORE_SCORE": "score",
 	"WVWSCORE_RELSCORE": "relscore",
 	"WVWSCORE_KD": "kd",
-	"WVWSCORE_HELP": "`!score` - Show the scores of your current WvW match-up.\n`!relscore` - Show the overall WvW score of the top world, along with the differences with the worlds on the second and the third place.\n`!kd` - Show the kill/death ratio of your current WvW match-up."
+	"WVWSCORE_HELP": "`!score` - Show the scores of your current WvW match-up.\n`!relscore` - Show the overall WvW score of the top world, along with the differences with the worlds on the second and the third place.\n`!kd` - Show the kill/death ratio of your current WvW match-up.",
+	"WVWSCORE_GREEN_COLOR": "Green",
+	"WVWSCORE_RED_COLOR": "Red",
+	"WVWSCORE_BLUE_COLOR": "Blue"
 }


### PR DESCRIPTION
- Some minor updates to the phrases
- Updated to the WvW commands responses to include all world names instead of just the host world. It also includes the color for those worlds now. For example:
```
Gandara + Underworld (Green): 323,674 (+100)
Elona Reach [DE] (Red): 247,734 (+64)
Ruins of Surmia + Seafarer's Rest (Blue): 193,280 (+88)
```