### PR TITLE
Fix checking for multiple permissions when there's no API key

### DIFF
--- a/features/builds.js
+++ b/features/builds.js
@@ -19,15 +19,16 @@ function messageReceived(message) {
 	var user_key;
 	async.waterfall([
 		function(next) { message.channel.startTyping(next); },
-		function(something, next) { db.checkKeyPermission(message.author.id, ['characters', 'builds'], next) },
-		function(hasPerm, next) {
-			if (! hasPerm) next(new Error("requires scope characters and builds"));
-			else next();
+		function(something, next) { db.getUserKey(message.author.id, next) },
+		function(key, next) {
+			if (! key) return next(new Error("endpoint requires authentication"));
+			if (! db.checkKeyPermission(message.author.id, ['characters', 'builds'], function(err, hasPerm) {
+				if (! hasPerm) return next(new Error("requires scope characters and builds"));
+				next(null, key);
+			}));
 		},
-		function(next) { db.getUserKey(message.author.id, next) },
 		function(key, next) {
 			// Get a list of characters first
-			if (! key) return next(new Error("endpoint requires authentication"));
 			user_key = key;
 			gw2.request('/v2/characters/', key, next);
 		},

--- a/lib/db.js
+++ b/lib/db.js
@@ -85,9 +85,11 @@ db.getUserToken = function(user_id, callback) {
 
 db.checkKeyPermission = function(user_id, permission, callback) {
 	if (! Array.isArray(permission)) permission = [ permission ];
+	if (permission.length == 0) return callback(null, true);
 	db.getUserToken(user_id, function(err, token_string) {
 		if (err) return callback(err);
 		token = JSON.parse(token_string);
+		if (! token || ! token.permissions) return callback(null, false);
 		var hasPerm = permission.every(p => (token.permissions.indexOf(p) > -1));
 		callback(null, hasPerm);
 	});


### PR DESCRIPTION
With the latest changes to check for multiple permissions simultaneously, it bot crashes when someone with no API key executes `!build`:

```
                var hasPerm = permission.every(p => (token.permissions.indexOf(p) > -1));
                                                          ^
TypeError: Cannot read property 'permissions' of null
```

This PR fixes this issue and also adds an additional check in case `db.checkKeyPermission` is called with a zero-length permission array (should return true in that case). It also changes the waterfall sequence in builds a little bit, since this will notify the person without an API key with the proper message that the bot doesn't know him/her.