### PR TITLE
Add whois feature to query people's account name

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -27,4 +27,4 @@ token = "" # Token for your discord bot user
 
 [features]
 language = "en"
-enabled = ["ranks", "motd", "wvw_score", "progression", "builds", "wiki", "session"]
+enabled = ["ranks", "motd", "wvw_score", "progression", "builds", "wiki", "session", "whois"]

--- a/features/whois.js
+++ b/features/whois.js
@@ -1,0 +1,45 @@
+var
+	async = require('async'),
+	db = require('../lib/db'),
+	phrases = require('../lib/phrases')
+;
+
+var bot_user;
+
+function messageReceived(message) {
+	if (message.content.match(new RegExp('^!'+phrases.get("WHOIS_WHOIS")+' (.*)+$', 'i'))) {
+		if (message.mentions.length === 0) return;
+		var user = message.mentions[0];
+		async.waterfall([
+			function(next) { message.channel.startTyping(next); },
+			function(something, next) {
+				if (user.id === bot_user.id) return next('bot user');
+				db.getAccountByUser(user.id, next);
+			},
+			function(account, next) { account ? next(null, account.name) : next('unknown'); }
+		], function(err, result) {
+			message.channel.stopTyping(function() {
+				if (err) {
+					switch (err) {
+						case 'unknown':
+							return message.reply(phrases.get("WHOIS_UNKNOWN"));
+						case 'bot user':
+							return message.reply(phrases.get("WHOIS_BOT", { user: bot_user.mention() }));
+						default:
+							return console.log(err.message);
+					}
+				} else if (result) {
+					if (user.id === message.author.id) message.reply(phrases.get("WHOIS_SELF", { account_name: result }));
+					else message.reply(phrases.get("WHOIS_KNOWN", { user: user.mention(), account_name: result }));
+				} else {
+					message.reply(phrases.get("WHOIS_UNKNOWN"));
+				}
+			});
+		});
+	}
+}
+
+module.exports = function(bot) {
+	bot.on("message", messageReceived);
+	bot.on("ready", function() { bot_user = bot.user; })
+};

--- a/phrases/whois.en.json
+++ b/phrases/whois.en.json
@@ -2,7 +2,7 @@
   "WHOIS_WHOIS": "whois",
   "WHOIS_HELP": "**__Whois__**\n\n`!whois <@user>` - Get the Guild Wars 2 account name from a user.",
   "WHOIS_KNOWN": "%{user} is also known as %{account_name}.",
-  "WHOIS_UNKNOWN": "I don't know who this user is. This user has not linked his API key.",
+  "WHOIS_UNKNOWN": "I don't know who this user is. This user has not linked their API key.",
   "WHOIS_BOT": "Oh hello there, I am %{user}!",
   "WHOIS_SELF": "Did you forgot who you are? You are %{account_name}!"
 }

--- a/phrases/whois.en.json
+++ b/phrases/whois.en.json
@@ -1,0 +1,8 @@
+{
+  "WHOIS_WHOIS": "whois",
+  "WHOIS_HELP": "**__Whois__**\n\n`!whois <@user>` - Get the Guild Wars 2 account name from a user.",
+  "WHOIS_KNOWN": "%{user} is also known as %{account_name}.",
+  "WHOIS_UNKNOWN": "I don't know who this user is. This user has not linked his API key.",
+  "WHOIS_BOT": "Oh hello there, I am %{user}!",
+  "WHOIS_SELF": "Did you forgot who you are? You are %{account_name}!"
+}


### PR DESCRIPTION
This will add the `!whois <@user>` command that allows people to look up someone else's account name if they've linked their API key.