### PR TITLE
Improve wiki and whois commands

### DIFF
--- a/features/whois.js
+++ b/features/whois.js
@@ -1,45 +1,52 @@
-var
-	async = require('async'),
-	db = require('../lib/db'),
-	phrases = require('../lib/phrases')
-;
+"use strict";
+const
+	Promise = require("bluebird"),
+	db = Promise.promisifyAll(require("../lib/db")),
+	phrases = require("../lib/phrases");
 
-var bot_user;
+let bot_user;
 
 function messageReceived(message) {
-	if (message.content.match(new RegExp('^!'+phrases.get("WHOIS_WHOIS")+' (.*)+$', 'i'))) {
-		if (message.mentions.length === 0) return;
-		var user = message.mentions[0];
-		async.waterfall([
-			function(next) { message.channel.startTyping(next); },
-			function(something, next) {
-				if (user.id === bot_user.id) return next('bot user');
-				db.getAccountByUser(user.id, next);
-			},
-			function(account, next) { account ? next(null, account.name) : next('unknown'); }
-		], function(err, result) {
-			message.channel.stopTyping(function() {
-				if (err) {
-					switch (err) {
-						case 'unknown':
-							return message.reply(phrases.get("WHOIS_UNKNOWN"));
-						case 'bot user':
-							return message.reply(phrases.get("WHOIS_BOT", { user: bot_user.mention() }));
-						default:
-							return console.log(err.message);
-					}
-				} else if (result) {
-					if (user.id === message.author.id) message.reply(phrases.get("WHOIS_SELF", { account_name: result }));
-					else message.reply(phrases.get("WHOIS_KNOWN", { user: user.mention(), account_name: result }));
-				} else {
-					message.reply(phrases.get("WHOIS_UNKNOWN"));
+	const messageAsync = Promise.promisifyAll(message);
+	const channelAsync = Promise.promisifyAll(message.channel);
+
+	if (message.content.match(new RegExp(`^!${phrases.get("WHOIS_WHOIS")} (.*)?$`, "i"))) {
+		if (message.mentions.length === 0) return; // No mentions? No answer
+		const user = message.mentions[0];
+		channelAsync.startTypingAsync()
+			.then(() => {
+				if (user.id === bot_user.id) throw new Error("bot user");
+
+				// Get the GW2 account data by user
+				return db.getAccountByUserAsync(user.id);
+			})
+			.then(account => {
+				if (!account) throw new Error("unknown user");
+
+				// Construct message
+				if (user.id === message.author.id) return phrases.get("WHOIS_SELF", { account_name: account.name });
+				else return phrases.get("WHOIS_KNOWN", { user: user.mention(), account_name: account.name });
+			})
+			.catch(err => {
+				// Capture errors and construct proper fail message
+				switch (err.message) {
+					case "bot user":
+						return phrases.get("WHOIS_BOT", { user: bot_user.mention() });
+					case "unknown user":
+						return phrases.get("WHOIS_UNKNOWN");
+					default:
+						console.log(`Error in whois command initiated by ${message.author.username}#${message.author.discriminator}: ${err.message}`);
+						return;
 				}
-			});
-		});
+			})
+			.finally(() => channelAsync.stopTypingAsync())
+			.then(text => messageAsync.replyAsync(text));
 	}
 }
 
-module.exports = function(bot) {
+module.exports = bot => {
 	bot.on("message", messageReceived);
-	bot.on("ready", function() { bot_user = bot.user; })
+	bot.on("ready", () => {
+		bot_user = bot.user;
+	})
 };

--- a/features/wiki.js
+++ b/features/wiki.js
@@ -1,12 +1,14 @@
-var
-	async = require('async'),
-	config = require('config'),
-	MWBot = require('mwbot'),
-	toMarkdown = require('to-markdown'),
-	phrases = require('../lib/phrases')
-;
+"use strict";
+const
+	MWBot = require("mwbot"),
+	Promise = require("bluebird"),
+	config = require("config"),
+	toMarkdown = require("to-markdown"),
+	db = Promise.promisifyAll(require("../lib/db")),
+	phrases = require("../lib/phrases");
 
-var wiki = new MWBot({
+const ttl = 1000 * 60 * 60; // Cache wiki responses for an hour to prevent flooding the wiki with requests with the same search terms
+const wiki = new MWBot({
 	apiUrl: "https://wiki.guildwars2.com/api.php"
 });
 
@@ -14,90 +16,110 @@ function htmlToMessage(html) {
 	return toMarkdown(html, {
 		converters: [
 			{ // Convert various stuff to plain-text
-				filter: ['a', 'small'],
-				replacement: function(innerHTML, node) { return innerHTML; }
+				filter: ["a", "small"],
+				replacement: (innerHTML, node) => innerHTML
 			},
 			{ // Filter out all unwanted tags
-				filter: function(node) {
-					return !node.nodeName.match(/^(b|strong|i|em|s|del|p)$/i);
-				},
-				replacement: function(innerHTML, node) { return ""; }
+				filter: node => !node.nodeName.match(/^(b|strong|i|em|s|del|p)$/i),
+				replacement: (innerHTML, node) => ""
 			}
 		]
 	});
 }
 
 function messageReceived(message) {
-	var match;
-	if (match = message.content.match(new RegExp('^!'+phrases.get("WIKI_WIKI")+' ?(.*)?$', 'i'))) {
-		async.waterfall([
-			function(next) { message.channel.startTyping(next); },
-			function(something, next) {
-				var term = match[1];
-				if (term) {
-					wiki.request({
-						action: 'query',
-						list: 'search',
-						srsearch: term,
-						srwhat: 'nearmatch'
-					}).then((response) => {
-						if (response.query.search.length == 0) {
-							return wiki.request({
-								action: 'query',
-								list: 'search',
-								srsearch: term,
-								srwhat: 'title'
-							});
-						}
-						return response;
-					}).then((response) => {
-						if (response.query.search.length > 0) {
-							return wiki.request({
-								action: 'parse',
-								page: response.query.search[0].title,
-								redirects: true,
-								prop: 'text'
-							});
-						}
-						throw { code: 'missingtitle' };
-					}).then((response) => {
-						next(null, response);
-					}).catch((error) => {
-						if (error.code == "missingtitle") next(new Error("not found"));
-						else next(new Error(error.info));
+	const messageAsync = Promise.promisifyAll(message);
+	const channelAsync = Promise.promisifyAll(message.channel);
+
+	let match;
+	if (match = message.content.match(new RegExp(`^!${phrases.get("WIKI_WIKI")} ?(.*)?$`, "i"))) {
+		const terms = match[1];
+		channelAsync.startTypingAsync()
+			.then(() => {
+				if (!terms) throw new Error("no title");
+
+				// Get cache if it exists
+				return db.getCachedResponseAsync("wiki", terms).then(cache => {
+					if (typeof cache === "string") return cache;
+
+					// Only search if we have something to search for
+					return wiki.request({
+						action: "query",
+						list: "search",
+						srsearch: terms,
+						srwhat: "nearmatch"
 					});
-				} else {
-					next(new Error("no title"));
-				}
-			},
-			function(response, next) {
-				var text = response.parse.text['*'];
-				if (text) {
+				});
+			})
+			.then(response => {
+				if (typeof response === "string") return response; // We got a cached response
+				if (response.query.search.length > 0) return response; // We got a live response with results
+
+				// The original nearmatch search didn't give us any results, proceed with title search
+				return wiki.request({
+					action: "query",
+					list: "search",
+					srsearch: terms,
+					srwhat: "title"
+				});
+			})
+			.then(response => {
+				if (typeof response === "string") return response; // We got a cached response
+				if (response.query.search.length === 0) throw new Error("not found"); // No results
+
+				// We have found something, get the first page result
+				return wiki.request({
+					action: "parse",
+					page: response.query.search[0].title,
+					redirects: true,
+					prop: "text"
+				});
+			})
+			.catch(err => {
+				// Make sure we have sane errors
+				if (err.code === "missingtitle") throw new Error("not found");
+				else if (err.info) throw new Error(err.info);
+				throw err;
+			})
+			.then(response => {
+				if (typeof response === "string") {
+					// We got a cached response
+					return response;
+				} else if (response.parse.text["*"]) {
+					// We got a live response
+					let text = response.parse.text["*"];
+					const title = response.parse.title;
+
+					// Construct message
 					text = htmlToMessage(text).split("\n")[0].trim();
-					var url = encodeURI("https://wiki.guildwars2.com/wiki/"+response.parse.title);
-					if (text) text += "\n\n"+phrases.get("WIKI_MORE", { url: url });
-					else text = phrases.get("WIKI_LINK", { title: response.parse.title, url: url });
-					next(null, text);
-				} else {
-					next(new Error("not found"));
+					const url = encodeURI(`https://wiki.guildwars2.com/wiki/${title}`);
+					if (text) text += "\n\n" + phrases.get("WIKI_MORE", { url });
+					else text = phrases.get("WIKI_LINK", { title, url });
+
+					// Cache it
+					return db.saveCachedResponseAsync("wiki", terms, text, ttl).return(text);
 				}
-			}
-		], function(err, result) {
-			message.channel.stopTyping(function() {
-				if (err) {
-					switch (err.message) {
-						case "not found": return message.reply(phrases.get("WIKI_NOT_FOUND"));
-						case "no title": return message.reply(phrases.get("WIKI_NO_TERM"));
-						default: return message.reply(phrases.get("WIKI_ERROR", { error: err.message || "" }));
-					}
-				} else {
-					message.reply(result);
+				throw new Error("not found"); // No results
+			})
+			.catch(err => {
+				// Capture errors and construct proper fail message
+				switch (err.message) {
+					case "not found":
+						const text = phrases.get("WIKI_NOT_FOUND");
+						// Cache it
+						return db.saveCachedResponseAsync("wiki", terms, text, ttl).return(text);
+					case "no title":
+						return phrases.get("WIKI_NO_TERM");
+					default:
+						console.log(`Error in wiki command initiated by ${message.author.username}#${message.author.discriminator}: ${err.message}`);
+						return phrases.get("WIKI_ERROR", { error: err.message || "" });
 				}
-			});
-		});
+			})
+			.finally(() => channelAsync.stopTypingAsync())
+			.then(text => messageAsync.replyAsync(text));
 	}
 }
 
-module.exports = function(bot) {
+module.exports = bot => {
 	bot.on("message", messageReceived);
 };

--- a/phrases/wiki.en.json
+++ b/phrases/wiki.en.json
@@ -3,7 +3,7 @@
 	"WIKI_HELP": "**__Wiki__**\n\n`!wiki <title>` - Search the wiki for an article and return a summary and the article link if available.",
 	"WIKI_LINK": "%{title}: %{url}",
 	"WIKI_MORE": "More: %{url}",
-	"WIKI_NO_TERM": "I don't know what to look for. Please include a wiki article title.",
-	"WIKI_NOT_FOUND": "I could not find what you were looking for. Try using a different wiki article title.",
+	"WIKI_NO_TERM": "I don't know what to look for. Please include a wiki article title or search terms.",
+	"WIKI_NOT_FOUND": "I could not find what you were looking for. Try using different search terms.",
 	"WIKI_ERROR": "Something went wrong. %{error}"
 }


### PR DESCRIPTION
I saw that you were moving towards using promises, so I decided to rewrite the two commands I made earlier to also support that. The code is more readable now.

Also, every wiki result is now cached with a ttl of 1 hour to prevent flooding the wiki with requests with the same search terms. It's using the already existing db function in a way it was not originally meant to, but it works this way too for now.