### PR TITLE
Fix span elements not being included in wiki text parsing

### DIFF
--- a/features/wiki.js
+++ b/features/wiki.js
@@ -16,8 +16,8 @@ function htmlToMessage(html) {
 	return toMarkdown(html, {
 		converters: [
 			{ // Convert various stuff to plain-text
-				filter: ["a", "small"],
-				replacement: (innerHTML, node) => innerHTML
+				filter: ["a", "small", "span"],
+				replacement: (innerHTML, node) => node.style.display != "none" ? innerHTML : ""
 			},
 			{ // Filter out all unwanted tags
 				filter: node => !node.nodeName.match(/^(b|strong|i|em|s|del|p)$/i),


### PR DESCRIPTION
This occurred on the [Ascended trinket](https://wiki.guildwars2.com/wiki/Ascended_trinket) page.

> Ascended trinkets are trinkets (rings, accessories, and amulets) of **Ascended** rarity.

The marked word is displayed in a different color with a `<span>` tag on the wiki. As those tags were skipped, it wasn't shown in the short information text.