### PR TITLE
Add single channel filter to all commands to the config

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -26,6 +26,7 @@ motd_excluded_subdomains = [ # An array of url subdomains of which the url shoul
 clientid = "" # Used to generate a link to add the bot to a server
 client_secret = "" # Only required if "web" feature is enabled
 token = "" # Token for your discord bot user
+channel = "" # Channel the bot listens on. "" means all channels
 
 # The "web" feature is disabled by default, enabling it adds a webs server which allows users to login and view more detailed reports and configure some options.
 [web]

--- a/discord_bot.js
+++ b/discord_bot.js
@@ -3,7 +3,8 @@ var
 	config = require('config'),
 	Discord = require('discord.js'),
 	gw2 = require('./lib/gw2'),
-	phrases = require('./lib/phrases')
+	phrases = require('./lib/phrases'),
+	filter = require('./lib/filter')
 ;
 
 var language = config.has('features.language') ? config.get('features.language') : "en";
@@ -30,6 +31,7 @@ bot.on("disconnected", function() {
 
 bot.on("message", function(message) {
 	if (message.content.match(new RegExp('^!'+phrases.get("CORE_HELP")+'$', 'i'))) {
+		if (filter.filterChannel(message)) return;
 		var help = features.map(f => phrases.get(f.toUpperCase()+"_HELP")).filter(f => !!f).join("\n\n").trim();
 		message.author.sendMessage("```Commands```\n"+help);
 		return;

--- a/features/builds.js
+++ b/features/builds.js
@@ -2,7 +2,8 @@ var
 	Promise = require('bluebird'),
 	db = Promise.promisifyAll(require('../lib/db')),
 	phrases = require('../lib/phrases'),
-	gw2 = require('../lib/gw2')
+	gw2 = require('../lib/gw2'),
+	filter = require('../lib/filter')
 ;
 
 function startTyping(channel) {
@@ -101,6 +102,7 @@ function messageReceived(message) {
 	var privacy_cmd = new RegExp('!('+phrases.get("BUILDS_PRIVACY")+') (.+) (private|guild|public)$', 'i');
 	var matches = message.content.match(traits_cmd) || message.content.match(equip_cmd) || message.content.match(privacy_cmd);
 	if (! matches) return;
+	if (filter.filterChannel(message)) return;
 	var cmd = matches[1];
 	var character = matches[2].replace(/<@\d+>/, "").trim();
 	if (cmd === phrases.get("BUILDS_PRIVACY")) {

--- a/features/kills.js
+++ b/features/kills.js
@@ -2,7 +2,8 @@ var
 	Promise = require('bluebird'),
 	db = Promise.promisifyAll(require('../lib/db')),
 	gw2 = require('../lib/gw2'),
-	phrases = require('../lib/phrases')
+	phrases = require('../lib/phrases'),
+	filter = require('../lib/filter')
 ;
 
 function getRaids(user) {
@@ -48,6 +49,7 @@ function getRaids(user) {
 function messageReceived(message) {
 	var cmd = new RegExp('^!' + phrases.get('KILLS_KILLS') + '$', 'i');
 	if (! message.content.match(cmd)) return;
+	if (filter.filterChannel(message)) return;
 	message.channel.startTyping();
 	getRaids(message.author)
   .then(res => message.reply(res))

--- a/features/li.js
+++ b/features/li.js
@@ -2,7 +2,8 @@ var
 	Promise = require('bluebird'),
 	db = Promise.promisifyAll(require('../lib/db')),
 	gw2 = require('../lib/gw2'),
-	phrases = require('../lib/phrases')
+	phrases = require('../lib/phrases'),
+	filter = require('../lib/filter')
 ;
 
 const li_id = 77302; // ID number for Legendary Insights
@@ -45,6 +46,7 @@ function countLI(user) {
 function messageReceived(message) {
 	var cmd = new RegExp('^!'+phrases.get("LI_CMD")+'$', 'i');
 	if (! message.content.match(cmd)) return;
+	if (filter.filterChannel(message)) return;
 	message.channel.startTyping();
 	countLI(message.author)
 	.then(count => message.reply(phrases.get("LI_SHOW", { count })))

--- a/features/progression.js
+++ b/features/progression.js
@@ -2,13 +2,15 @@ var
 	Promise = require('bluebird'),
 	db = Promise.promisifyAll(require('../lib/db')),
 	phrases = require('../lib/phrases'),
-	gw2 = require('../lib/gw2')
+	gw2 = require('../lib/gw2'),
+	filter = require('../lib/filter')
 ;
 
 function messageReceived(message) {
 	var fractal_cmd = phrases.get("PROGRESSION_FRACTAL");
 	var wvw_cmd = phrases.get("PROGRESSION_WVW");
 	if (! message.content.match(new RegExp('^!('+fractal_cmd+'|'+wvw_cmd+')$', 'i'))) return;
+	if (filter.filterChannel(message)) return;
 	message.channel.startTyping();
 	db.checkKeyPermissionAsync(message.author.id, 'progression')
 		.then(hasPerm => {

--- a/features/session.js
+++ b/features/session.js
@@ -3,7 +3,8 @@ var
 	db = Promise.promisifyAll(require('../lib/db')),
 	gw2 = require('../lib/gw2'),
 	diff = require('deep-diff').diff,
-	phrases = require('../lib/phrases')
+	phrases = require('../lib/phrases'),
+	filter = require('../lib/filter')
 ;
 
 const session_prefix = 'session';
@@ -317,6 +318,7 @@ function presenceChanged(oldState, newState) {
 function messageReceived(message) {
 	var cmd = new RegExp('^!'+phrases.get("SESSION_SHOWLAST")+'$', 'i');
 	if (! message.content.match(cmd)) return;
+	if (filter.filterChannel(message)) return;
 	message.channel.startTyping();
 	parseSession(message.author)
 	.catch(err => {

--- a/features/whois.js
+++ b/features/whois.js
@@ -2,7 +2,8 @@
 const
 	Promise = require("bluebird"),
 	db = Promise.promisifyAll(require("../lib/db")),
-	phrases = require("../lib/phrases");
+	phrases = require("../lib/phrases"),
+	filter = require('../lib/filter');
 
 let bot_user;
 
@@ -11,6 +12,7 @@ function messageReceived(message) {
 
 	if (message.content.match(new RegExp(`^!${phrases.get("WHOIS_WHOIS")} (.*)?$`, "i"))) {
 		if (message.mentions.users.length === 0) return; // No mentions? No answer
+		if (filter.filterChannel(message)) return;
 		const user = message.mentions.users.first();
 		if (! user) return;
 		channel.startTyping();

--- a/features/wiki.js
+++ b/features/wiki.js
@@ -5,7 +5,8 @@ const
 	config = require("config"),
 	toMarkdown = require("to-markdown"),
 	db = Promise.promisifyAll(require("../lib/db")),
-	phrases = require("../lib/phrases");
+	phrases = require("../lib/phrases"),
+	filter = require('../lib/filter');
 
 const ttl = 1000 * 60 * 60; // Cache wiki responses for an hour to prevent flooding the wiki with requests with the same search terms
 
@@ -57,6 +58,7 @@ function getWikiLang(lang) {
 function messageReceived(message) {
 	let match;
 	if (match = message.content.match(new RegExp(`^!${phrases.get("WIKI_WIKI")}-?([a-zA-Z]*) ?(.*)?$`, "i"))) {
+		if (filter.filterChannel(message)) return;
 		const lang = match[1];
 		const terms = match[2];
 		if (! terms) return;

--- a/features/wvw_score.js
+++ b/features/wvw_score.js
@@ -3,7 +3,8 @@ var
 	config = require('config'),
 	db = Promise.promisifyAll(require('../lib/db')),
 	gw2 = require('../lib/gw2'),
-	phrases = require('../lib/phrases')
+	phrases = require('../lib/phrases'),
+	filter = require('../lib/filter')
 ;
 
 var guild_world = config.has('world.id') ? config.get('world.id') : null;
@@ -129,6 +130,7 @@ function messageReceived(message) {
 	var relscore_cmd = phrases.get("WVWSCORE_RELSCORE");
 	var kd_cmd = phrases.get("WVWSCORE_KD");
 	if (! message.content.match(new RegExp('^!('+match_cmd+'|'+score_cmd+'|'+relscore_cmd+'|'+kd_cmd+')$', 'i'))) return;
+	if (filter.filterChannel(message)) return;
 	message.channel.startTyping();
 	db.getAccountByUserAsync(message.author.id)
 		.then(account => (account && account.world) ? account.world : guild_world)

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,0 +1,19 @@
+var
+	config = require('config'),
+	phrases = require('./phrases')
+;
+
+var filter = {};
+
+var listenChannel = config.has('discord.channel') ? config.get('discord.channel') : "";
+
+filter.filterChannel = function(message) {
+	if (message.channel.type !== "text") return;
+	if (listenChannel && listenChannel !== message.channel.name) {
+		message.author.sendMessage(phrases.get("CORE_WRONG_CHANNEL", {channel: listenChannel}));
+		return true;
+	}
+	return false;
+}
+
+module.exports = filter;

--- a/phrases/core.en.json
+++ b/phrases/core.en.json
@@ -5,5 +5,6 @@
 	"CORE_GOLD": "%{count}g",
 	"CORE_SILVER": "%{count}s",
 	"CORE_COPPER": "%{count}c",
-	"CORE_ERROR": "Sorry, an error has occured."
+	"CORE_ERROR": "Sorry, an error has occured.",
+	"CORE_WRONG_CHANNEL": "Sorry, I can only accept commands on the **%{channel}** channel"
 }


### PR DESCRIPTION
This adds the ability to limit commands to run on one text channel. If the bot hears a command that is not on the specified channel, it will direct message them which channel it will listen on.

This does not affect group channels or direct messages. Those will continue working as is.